### PR TITLE
fix checkpoint

### DIFF
--- a/models/nn.py
+++ b/models/nn.py
@@ -127,10 +127,12 @@ def timestep_embedding(timesteps, dim, max_period=10000):
     return embedding
 
 
-def torch_checkpoint(func, args, flag, preserve_rng_state=False):
+def torch_checkpoint(func, args, flag, preserve_rng_state=True):
     # torch's gradient checkpoint works with automatic mixed precision, given torch >= 1.8
     if flag:
         return torch.utils.checkpoint.checkpoint(
-            func, *args, preserve_rng_state=preserve_rng_state)
+            func, *args, 
+            use_reentrant=True,
+            preserve_rng_state=preserve_rng_state)
     else:
         return func(*args)


### PR DESCRIPTION
1. make `use_reentrant=True` explicit, because it will default to true if it is not assigned
2. fix gradient checkpoint when it used with dropout turned on. if `preserve_rng_state=False`,  the dropout will definitely not work, because gradient flows into wrong input cells

it can be shown with a failed 300 epoch training, with `preserve_rng_state=False` and `use_checkpoint=True`.

some samples at the end of one failed training:

![image](https://github.com/ankanbhunia/PIDM/assets/32255912/1c5dc4c6-b484-45cd-8406-da4b0114b23b)



